### PR TITLE
apq8084-common: Enable single/dual SIM support with fragments

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -158,28 +158,6 @@
         </interface>
     </hal>
      <hal format="hidl">
-        <name>android.hardware.radio</name>
-        <transport>hwbinder</transport>
-        <version>1.1</version>
-        <interface>
-            <name>IRadio</name>
-            <instance>slot1</instance>
-        </interface>
-        <interface>
-            <name>ISap</name>
-            <instance>slot1</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
-        <name>android.hardware.radio.deprecated</name>
-        <transport>hwbinder</transport>
-        <version>1.0</version>
-        <interface>
-            <name>IOemHook</name>
-            <instance>slot1</instance>
-        </interface>
-     </hal>
-     <hal format="hidl">
         <name>android.hardware.renderscript</name>
         <transport arch="32">passthrough</transport>
         <version>1.0</version>

--- a/radio/dual/board.mk
+++ b/radio/dual/board.mk
@@ -1,0 +1,9 @@
+# Audio
+AUDIO_FEATURE_ENABLED_MULTI_VOICE_SESSIONS := true
+AUDIO_FEATURE_SAMSUNG_DUAL_SIM := true
+
+# Properties
+TARGET_SYSTEM_PROP += $(COMMON_PATH)/radio/dual/system.prop
+
+# Radio/RIL
+DEVICE_MANIFEST_FILE += $(COMMON_PATH)/radio/dual/manifest.xml

--- a/radio/dual/manifest.xml
+++ b/radio/dual/manifest.xml
@@ -1,0 +1,27 @@
+<manifest version="1.0" type="device">
+    <hal format="hidl">
+        <name>android.hardware.radio</name>
+        <transport>hwbinder</transport>
+        <version>1.1</version>
+        <interface>
+            <name>IRadio</name>
+            <instance>slot1</instance>
+            <instance>slot2</instance>
+        </interface>
+        <interface>
+            <name>ISap</name>
+            <instance>slot1</instance>
+            <instance>slot2</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
+        <name>android.hardware.radio.deprecated</name>
+        <transport>hwbinder</transport>
+        <version>1.0</version>
+        <interface>
+            <name>IOemHook</name>
+            <instance>slot1</instance>
+            <instance>slot2</instance>
+        </interface>
+    </hal>
+</manifest>

--- a/radio/dual/product.mk
+++ b/radio/dual/product.mk
@@ -1,0 +1,3 @@
+# Radio/RIL
+PRODUCT_PACKAGES += \
+    rild_dsds.rc

--- a/radio/dual/system.prop
+++ b/radio/dual/system.prop
@@ -1,0 +1,5 @@
+# RIL
+persist.radio.multisim.config=dsds
+ro.multisim.simslotcount=2
+ro.multisim.set_audio_params=true
+ro.telephony.ril.config=simactivation

--- a/radio/single/board.mk
+++ b/radio/single/board.mk
@@ -1,0 +1,2 @@
+# Radio/RIL
+DEVICE_MANIFEST_FILE += $(COMMON_PATH)/radio/single/manifest.xml

--- a/radio/single/manifest.xml
+++ b/radio/single/manifest.xml
@@ -1,0 +1,24 @@
+<manifest version="1.0" type="device">
+    <hal format="hidl">
+        <name>android.hardware.radio</name>
+        <transport>hwbinder</transport>
+        <version>1.1</version>
+        <interface>
+            <name>IRadio</name>
+            <instance>slot1</instance>
+        </interface>
+        <interface>
+            <name>ISap</name>
+            <instance>slot1</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
+        <name>android.hardware.radio.deprecated</name>
+        <transport>hwbinder</transport>
+        <version>1.0</version>
+        <interface>
+            <name>IOemHook</name>
+            <instance>slot1</instance>
+        </interface>
+    </hal>
+</manifest>


### PR DESCRIPTION
Leaving this here for anyone interested.

Quote @chirs241097:
> If I remove persist.radio.multisim.config from the property list, SIM 1 works just fine(as in older revisions). But if I leave it there, the first rild would die soon after it is launched. The second rild runs fine. As a result, the system behavior is very weird: it says "No SIM card - <carrier name of SIM 1>" in the status bar, even if I have only slot 1 occupied. The IMEI of slot 2 is shown as unknown. The IMEI of slot 1, however, shows up correctly.

> Here is the log from logcat -b radio with persist.radio.multisim.config set:
> https://paste.ubuntu.com/p/ptTcdvhy7s/
> Please note that when this log is taken, only slot 1 is occupied. Slot 2 never worked since it's IMEI is actually unknown.
> I have noticed potential permission issue on /dev/gsm_boot0 but nothing happens even if I chown it to radio:radio(Can't open modem boot (/dev/gsm_boot0) with -1 disappears from the log though).