### PR TITLE
Move XTRA_SERVER entries to overlays

### DIFF
--- a/configs/gps.conf
+++ b/configs/gps.conf
@@ -1,8 +1,8 @@
 #Uncommenting these urls would only enable
 #the power up auto injection and force injection(test case).
-XTRA_SERVER_1=https://xtrapath1.izatcloud.net/xtra3grc.bin
-XTRA_SERVER_2=https://xtrapath2.izatcloud.net/xtra3grc.bin
-XTRA_SERVER_3=https://xtrapath3.izatcloud.net/xtra3grc.bin
+#XTRA_SERVER_1=https://xtrapath1.izatcloud.net/xtra3grc.bin
+#XTRA_SERVER_2=https://xtrapath2.izatcloud.net/xtra3grc.bin
+#XTRA_SERVER_3=https://xtrapath3.izatcloud.net/xtra3grc.bin
 
 #Version check for XTRA
 #DISABLE = 0

--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2011, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<!-- These resources are around just to allow their values to be customized
+     for different hardware and product builds. -->
+<resources>
+
+    <!-- Values for GPS configuration -->
+    <string-array translatable="false" name="config_gpsParameters">
+        <item>XTRA_SERVER_1=https://xtrapath1.izatcloud.net/xtra3grc.bin</item>
+        <item>XTRA_SERVER_2=https://xtrapath2.izatcloud.net/xtra3grc.bin</item>
+        <item>XTRA_SERVER_3=https://xtrapath3.izatcloud.net/xtra3grc.bin</item>
+    </string-array>
+
+</resources>


### PR DESCRIPTION
* XTRA_SERVERs are important, right? Like to get the almanac data
  necessary for aGPS. Without the XTRA download, the chip needs to
  collect sufficient navigation messages from the birds to compute
  where they are in order to make sense of the ranging signals.
* Well, it seems that O doesn't like reading these entries from the
  gps.conf file.

  When in gps.conf:
  GpsXtraDownloader: No XTRA servers were specified in the GPS configuration

  When in overlay:
  <that noise doesn't exist>

* This seems to return GPS fix performance to what we had in N.

Original author: Kevin F. Haggerty <haggertk@lineageos.org>